### PR TITLE
Various fixes for By-Component mode in 1.7

### DIFF
--- a/grapher/Models/AccelGUI.cs
+++ b/grapher/Models/AccelGUI.cs
@@ -122,7 +122,6 @@ namespace grapher
             settings.rotation = ApplyOptions.Rotation.Field.Data;
             settings.outputDPI = Helper.CalculatOutputDPI(ApplyOptions.Sensitivity.Field.Data);
 
-            // TODO - separate sensitivity fields, add new label for ratio
             settings.yxOutputDPIRatio = ApplyOptions.YToXRatio.Value;
             settings.inputSpeedArgs.combineMagnitudes = ApplyOptions.IsWhole;
             ApplyOptions.SetArgsFromActiveValues(ref settings.argsX, ref settings.argsY);

--- a/grapher/Models/Calculations/AccelCalculator.cs
+++ b/grapher/Models/Calculations/AccelCalculator.cs
@@ -394,7 +394,7 @@ namespace grapher.Models.Calculations
                 mouseInputData.y = ceil;
                 mouseInputData.time = MeasurementTime*timeFactor;
                 mouseInputData.velocity = DecimalCheck(Velocity(0, ceil, mouseInputData.time));
-                mouseInputData.angle = 0;
+                mouseInputData.angle = Math.PI / 2;
                 magnitudes.Add(mouseInputData);
             }
 
@@ -586,21 +586,9 @@ namespace grapher.Models.Calculations
                 mouseInputData.x = ceilX;
                 mouseInputData.y = ceilY;
                 mouseInputData.time = timeFactor;
-
-                if (mouseInputData.x == 1 && mouseInputData.time == 1)
-                {
-                    Console.WriteLine("Oops");
-                }
-
             }
 
             mouseInputData.velocity = DecimalCheck(Velocity(mouseInputData.x, mouseInputData.y, mouseInputData.time));
-
-            if (double.IsNaN(mouseInputData.velocity))
-            {
-                Console.WriteLine("oopsie");
-            }
-
             mouseInputData.angle = angle;
             return mouseInputData;
         }

--- a/grapher/Models/Options/ApplyOptions.cs
+++ b/grapher/Models/Options/ApplyOptions.cs
@@ -108,7 +108,7 @@ namespace grapher.Models.Options
             
             WholeVectorCheckBox.Checked = settings.inputSpeedArgs.combineMagnitudes;
             ByComponentVectorCheckBox.Checked = !settings.inputSpeedArgs.combineMagnitudes;
-            ByComponentVectorXYLock.Checked = settings.argsX.Equals(settings.argsY);
+            ByComponentVectorXYLock.Checked = settings.argsX.IsEquivalentTo(settings.argsY);
             OptionSetX.SetActiveValues(ref settings.argsX);
             OptionSetY.SetActiveValues(ref settings.argsY);
 

--- a/grapher/Models/Serialized/SettingsManager.cs
+++ b/grapher/Models/Serialized/SettingsManager.cs
@@ -203,7 +203,9 @@ namespace grapher.Models.Serialized
             settings.minimumSpeed = UserProfile.minimumSpeed;
             settings.lrOutputDPIRatio = UserProfile.lrOutputDPIRatio;
             settings.udOutputDPIRatio = UserProfile.udOutputDPIRatio;
-            settings.inputSpeedArgs = UserProfile.inputSpeedArgs;
+            settings.inputSpeedArgs.inputSmoothHalflife = UserProfile.inputSpeedArgs.inputSmoothHalflife;
+            settings.inputSpeedArgs.scaleSmoothHalflife = UserProfile.inputSpeedArgs.scaleSmoothHalflife;
+            settings.inputSpeedArgs.outputSmoothHalflife = UserProfile.inputSpeedArgs.outputSmoothHalflife;
         }
 
         public GUISettings MakeGUISettingsFromFields()


### PR DESCRIPTION
Various fixes to By-Component:
- If "By-Component" is active, display that in UI, keeping correct box checked
- If both X and Y accel arguments are equivalent, check the X=Y By-Component checkbox
- If X and Y accel arguments are not equivalent, display correct accel curve on Y chart

Also, some code clean-up where I noticed.